### PR TITLE
chore: 🍰 Refine Rebanding And Deployment – Next Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ __Try out our deployed [development environment](https://stage.ocelot.social).__
 
 Visit our staging networks:
 
-- central staging network: [stage.ocelot.social](https://stage.ocelot.social).
+- central staging network: [stage.ocelot.social](https://stage.ocelot.social)
+- Yunite staging network: [stage.yunite.me](https://stage.yunite.me)
 <!-- - rebranded staging network: [rebrand.ocelot.social](https://stage.ocelot.social). -->
 
 Logins:

--- a/deployment/kubernetes/.gitignore
+++ b/deployment/kubernetes/.gitignore
@@ -1,4 +1,5 @@
 /dns.values.yaml
+/dns.values*-ME.yaml
 /nginx.values.yaml
 /values.yaml
 /values*-ME.yaml


### PR DESCRIPTION
## 🍰 Pull Request

Refine rebanding and deployment – next step.

### Issues

- fixes #7

### Additional Informations

@UlfTramsen schrieb auf Discord:

Am 24.09.2022:

```text
Das sind so die ersten Wünsche um die beiden Auftritte miteinander verschmelzen:
Navigation
Themen bitte fest verlinken mit https://yunite.org/themen/
Die Icons dieser Seite würde ich gerne verlinken mit Suchausgabe der entsprechenden Kategorie.
Wenn jemand nicht eingeloggt ist wird entsprechend erst login gezeigt und dann weiter geleitet auf Ergebnis
Könnt Ihr mich mit passenden Links versorgen?

Die aktuelle Themenfilter-Funktion bitte im Filtersymbol integrieren.
Form, Abstände Minuspunkte bitte von .org übernehmen und statisch verlinken - wenn es da Probleme gibt können wir auch .org noch etwas justieren bis es passt.
Bis auf Gruppen - das ist ein Link aus Ozelot, wenn dieser dann existiert.
Dahinter dann die Suche und so weiter in der Navigation

Fuß
Bitte nur 
Datenschutz - Impressum - v1.1.1
Rest raus

Den Fuß bei Mobil ausblenden und nur im Menu die Punkte unten mit ausgeben.
```

```text
PS gerne Eure Meinung / Feedback dazu 🙂
```

```text
Und die links zwischen den Plattformen sollten immer im gleichen Fenster aufgehen
```

### Todo

- [x] have a look on  #16
  - [x] merge this into the other
- [ ] configure and rebrand footer items, see @UlfTramsen above ☝🏼
- [ ] general (stage and production):
  - [ ] check all the data entries:
    - [ ] in all the branding files
    - [ ] in `package.json`
    - [ ] set correct e-mails in Kubernetes Helm YAML files
- [ ] yunite.me
  - [ ] e-mails have still the ocelot.social logo?
    - [x] is already prepared in `deployment/kubernetes/values-YUNITE-ME.yaml`
- [x] stage.yunite.me
  - [x] e-mails have still the ocelot.social logo!
  - [x] overtake `SHOW_GROUP_BUTTON_IN_HEADER` in `webapp/constants/groups.js` of ocelot.social deploy/reband
    - see #75
  - [x] invent a (paretly automatic) deployment for the groups with branding
    - [x] on ocelot.social main repo on groups branch `5059-epic-groups`: ( https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/5408 )
      - [x] push a Docker image to DockerHub org `ocelotnetwork` taged `<app>-groups`
    - [x] on yunite deploy-rebrand repo on new branch `stage-5059-epic-groups`:
      - [x] push a Docker image to DockerHub account `tirokk` taged `<app>-groups-branded`
      - [x] deploy it automaticaly to staging
  - [x] add it as live demo in main `READM.md`
